### PR TITLE
Bump deCONZ Add-on to 2.05.55

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## **2.05.55** - 2018-01-15
+### Added
+- Add VNC server support for viewing the deCONZ ZigBee mesh
+### Changed
+- Bump deCONZ to 2.05.54
+
 ## **2.05.54** - 2018-01-08
 ### Changed
 - Bump deCONZ to 2.05.54

--- a/deconz/FIRMWARE-UPGRADE.md
+++ b/deconz/FIRMWARE-UPGRADE.md
@@ -16,6 +16,16 @@ GW update firmware found: /usr/share/deCONZ/firmware/deCONZ_Rpi_0x261e0500.bin.G
 GW firmware version: 0x261c0500
 GW firmware version shall be updated to: 0x261e0500
 ```
+
+Alternatively you can log into your Hass.io host over SSH (set up in step 1) and run this command to extract the GCF line:
+```docker ps | grep deconz | awk '{print $NF}' | while read cont; do echo "Searching in $cont"; docker logs $cont 2>&1 | grep 'GCF\|firmware version'; done
+
+Searching in addon_a0d7b954_deconz
+23:59:37:341 GW update firmware found: /usr/share/deCONZ/firmware/deCONZ_Rpi_0x262f0500.bin.GCF
+23:59:38:534 Device firmware version 0x261F0500
+00:01:47:443 GW firmware version: 0x261f0500
+```
+
 2. Stop the deCONZ add-on.
 3. Log in to your Hass.io host over SSH (set up in step 1).
 4. Invoke the firmware upgrade script:  

--- a/deconz/README.md
+++ b/deconz/README.md
@@ -26,6 +26,10 @@ Raise any issues with this Add-on as an issue at https://github.com/marthoc/hass
 
 You can upgrade the firmware of your RaspBee / Conbee device by following the instructions here: https://github.com/marthoc/hassio-addons/blob/master/deconz/FIRMWARE-UPGRADE.md. 
 
+## Viewing the deCONZ ZigBee Mesh
+
+Set the configuration variable 'vnc active' to true to enable a VNC server in the Add-on that will allow you to connect to the addon at the port 'vnc port' using the password 'vnc password' to view the deCONZ ZigBee Mesh. (Thanks to @neffs for adding this long-requested feature!) (Note: the default password is "changeme" but this should be changed before enabling VNC.)
+
 ## Important!!
 
 This Add-on's version number tracks deCONZ releases from Dresden Elektronik; changes to this Add-on's base image and settings may be made between deCONZ releases and incorporated when a new deCONZ version is released. A list of important/relevant changes is available at: https://github.com/marthoc/hassio-addons/blob/master/deconz/CHANGELOG.md.

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
     "name": "deCONZ",
-    "version": "2.05.54",
+    "version": "2.05.55",
     "slug": "deconz",
     "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
     "arch": ["amd64","armhf","aarch64"],

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -18,7 +18,12 @@
         "debug_aps": 0,
         "debug_zcl": 0,
         "debug_zdp": 0,
-        "debug_otau": 0
+        "debug_otau": 0,
+        "vnc": {
+          "active": false,
+          "port": 5900,
+          "password": "changeme"
+        }
     },
     "schema": {
         "deconz_device": "str",
@@ -28,7 +33,13 @@
         "debug_aps": "int(0,1)",
         "debug_zcl": "int(0,1)",
         "debug_zdp": "int(0,1)",
-        "debug_otau": "int(0,1)"    
+        "debug_otau": "int(0,1)",
+        "vnc": {
+          "active": "bool",
+          "port": "int(5900,5999)",
+          "password": "str"
+        }
+        
     },
     "image": "marthoc/hassio-addon-deconz-{arch}"
 }


### PR DESCRIPTION
...and add configuration variables for VNC server support added upstream in marthoc/deconz.
Closes #60.