### PR TITLE
Bump deCONZ Add-on to 2.05.57

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## **2.05.57** - 2019-01-20
+### Changed
+- Bump deCONZ to 2.05.57
+### Fixed
+- Fix Hass.io start scripts
+
 ## **2.05.55.1** - 2019-01-16
 ### Fixed
 - Fixed bugs in startup script

--- a/deconz/config.json
+++ b/deconz/config.json
@@ -1,6 +1,6 @@
 {
     "name": "deCONZ",
-    "version": "2.05.55.1",
+    "version": "2.05.57",
     "slug": "deconz",
     "description": "Control a ZigBee network with Conbee or RaspBee by Dresden Elektronik",
     "arch": ["amd64","armhf","aarch64"],


### PR DESCRIPTION
And, fix bugs preventing the deCONZ Add-on from working properly after VNC support was added.

Closes #65, Closes #66, Closes #67, Closes #70.