### PR TITLE
[DNS-O-Matic] Add "arch" key to config.json

### DIFF
--- a/dnsomatic/config.json
+++ b/dnsomatic/config.json
@@ -3,6 +3,7 @@
     "version": "1.1",
     "slug": "dnsomatic",
     "description": "Dynamic DNS via DNS-O-Matic",
+    "arch": ["amd64","armhf","aarch64"],
     "url": "https://github.com/marthoc/hassio-addons/tree/master/dnsomatic",
     "startup": "application",
     "boot": "auto",


### PR DESCRIPTION
Similar to the line in your Deconz addon, this also needs a `arch` string in here. Not sure if if it's `amd64` or not, just copied the one from your Deconz config.

It'll stop this from showing up in my logs `19-05-29 16:29:18 WARNING (MainThread) [hassio.store.data] Can't read /data/addons/git/69bb46cb/dnsomatic/config.json: required key not provided @ data['arch']. Got None`