### PR TITLE
Discontinue deCONZ Add-on

### DIFF
--- a/deconz/CHANGELOG.md
+++ b/deconz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **2.05.66** - 2019-07-22
+### Changed
+- Added discontinued message to README
+
 ## **2.05.66** - 2019-06-25
 ### Changed
 - Bump deCONZ to 2.05.66

--- a/deconz/README.md
+++ b/deconz/README.md
@@ -1,41 +1,22 @@
-# deCONZ
+# marthoc deCONZ
 
-Add-on to allow Home Assistant to control a ZigBee network with Conbee or RaspBee hardware by Dresden Elektronik.
+**IMPORTANT: This add-on is discontinued. Please switch to the deCONZ add-on in the Hass.io official repo. This add-on will not be updated past 2.05.66 and will eventually be deleted entirely. No fixes for any open issues will be forthcoming.**
 
-## First Steps
+## Migrating to the official Add-on
 
-If using RaspBee, you may need to edit config.txt on the root of your SD card for your RaspBee to be recognized and assigned a device name: see https://github.com/marthoc/hassio-addons/blob/master/deconz/RASPBEE-SETUP.md.
+To migrate, backup your deCONZ config via the Phoscon WebUI, then restore that config after installing/reinstalling:
 
-Before starting the add-on for the first time after installing **or upgrading**, in the add-on config you must specify the device name that has been assigned to your RaspBee/Conbee as the "deconz_device". Replace **null** and specify the device name in quotes (e.g. "/dev/ttyUSB0" or "/dev/ttyAMA0"). The other config options have sensible defaults that should not need to be changed unless you are debugging.
+1. Open the Phoscon WebUI.
+2. Open the hamburger menu.
+3. Select 'Gateway'.
+4. Select 'Backup Options'.
+5. Select 'Create Backup'.
+6. Select 'Start Download'.
+7. Uninstall this add-on, then install the official deCONZ add-on and configure it.
+8. Open the Phoscon WebUI, hamburger menu, Gateway, Backup Options.
+9. Select 'Load Backup', then Next.
+10. Browse for the file that downloaded in step 6.
+11. Select 'Load Backup'.
+12. Restart the official add-on.
 
-## Adding ZigBee Devices
-
-After installing and starting this addon in Hass.io, access the deCONZ WebUI ("Phoscon") to add ZigBee devices: http://hassio.local:8080
-
-The default username/password is delight/delight.
-
-## Configuring the Home Assistant deCONZ Component
-
-If `discovery:` is enabled in configuration.yaml, navigate to the Configuration - Integrations page after starting this Add-on to configure the deCONZ component.
-
-If `discovery:` is not enabled, follow these instructions to configure the deCONZ component: https://home-assistant.io/components/deconz/.
-
-Raise any issues with this Add-on as an issue at https://github.com/marthoc/hassio-addons.
-
-## Firmware Upgrades
-
-You can upgrade the firmware of your RaspBee / Conbee device by following the instructions here: https://github.com/marthoc/hassio-addons/blob/master/deconz/FIRMWARE-UPGRADE.md. 
-
-## Viewing the deCONZ ZigBee Mesh
-
-Set the configuration variable 'vnc active' to true to enable a VNC server in the Add-on that will allow you to connect to the addon at the port 'vnc port' using the password 'vnc password' to view the deCONZ ZigBee Mesh. (Thanks to @neffs for adding this long-requested feature!) (Note: the default password is "changeme" but this should be changed before enabling VNC.)
-
-## Important!!
-
-This Add-on's version number tracks deCONZ releases from Dresden Elektronik; changes to this Add-on's base image and settings may be made between deCONZ releases and incorporated when a new deCONZ version is released. A list of important/relevant changes is available at: https://github.com/marthoc/hassio-addons/blob/master/deconz/CHANGELOG.md.
-
-Use a 2.5A power supply for your Raspberry Pi 3! Strange behaviour with this Add-on may otherwise result.
-
-## Migrating to this Add-on
-
-To migrate deCONZ to Hass.io and this Add-on (or before uninstalling/reinstalling this Add-on), backup your deCONZ config via the Phoscon WebUI, then restore that config after installing/reinstalling. _You must perform these steps or your Light and Group names and other data will be lost!_ (However, your ZigBee devices will remain paired to your Conbee or RaspBee hardware.)
+_You must perform these steps or your Light and Group names and other data will be lost!_


### PR DESCRIPTION
marthoc's deCONZ add-on is now discontinued. The official Hass.io add-on has surpassed this add-on in terms of functionality and will be more actively developed and updated to take advantage of new Hass.io features. Please use the official add-on instead. This add-on will not be updated past deCONZ 2.05.66 and any new features or PR's will be closed without comment.